### PR TITLE
修复部分方法中的SSLV3_ALERT_HANDSHAKE_FAILURE问题

### DIFF
--- a/nonebot_plugin_picsearcher/animedb.py
+++ b/nonebot_plugin_picsearcher/animedb.py
@@ -32,8 +32,9 @@ headers = {
 
 async def get_pic_from_url(url: str):
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as resp1:
-            content = await resp1.read()
+        async with httpx.AsyncClient(verify=True) as client:
+            response = await client.get(url)
+            content = io.BytesIO(response.content)
     async with httpx.AsyncClient() as session:
         resp = await session.post(
             "https://aiapiv2.animedb.cn/ai/api/detect?force_one=1&model=anime",  # fuck fuck fuck, only httpx can pass waf

--- a/nonebot_plugin_picsearcher/ex.py
+++ b/nonebot_plugin_picsearcher/ex.py
@@ -3,7 +3,7 @@ import io
 from base64 import b64encode
 from typing import List, Tuple
 
-import aiohttp
+import aiohttp,httpx
 import nonebot
 from aiohttp.client_exceptions import InvalidURL
 from lxml.html import fromstring
@@ -66,8 +66,9 @@ async def get_pic_from_url(url: str):
     :return:
     """
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as resp:
-            content = io.BytesIO(await resp.read())
+        async with httpx.AsyncClient(verify=True) as client:
+            response = await client.get(url)
+            content = io.BytesIO(response.content)
             # Content_Length = resp.content_length
         data = FormData(boundary="----WebKitFormBoundaryB0NrMSYMfjY5r0l1")
         data.add_field(

--- a/nonebot_plugin_picsearcher/iqdb.py
+++ b/nonebot_plugin_picsearcher/iqdb.py
@@ -4,7 +4,7 @@ import io
 from typing import List, Tuple
 from urllib.parse import urljoin
 
-import aiohttp
+import aiohttp,httpx
 from lxml.html import fromstring
 from nonebot.adapters.onebot.v11 import MessageSegment
 
@@ -55,8 +55,9 @@ async def get_pic_from_url(url: str):
     :return:
     """
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as resp:
-            content = io.BytesIO(await resp.read())
+        async with httpx.AsyncClient(verify=True) as client:
+            response = await client.get(url)
+            content = io.BytesIO(response.content)
         data = aiohttp.FormData()  # boundary="----WebKitFormBoundaryuwjSiBcpPag4k159"
         data.add_field(name="MAX_FILE_SIZE", value="")
         for i in range(1, 7):

--- a/nonebot_plugin_picsearcher/saucenao.py
+++ b/nonebot_plugin_picsearcher/saucenao.py
@@ -2,7 +2,7 @@
 import io
 from typing import List, Tuple
 
-import aiohttp
+import aiohttp,httpx
 from lxml.html import fromstring
 from nonebot.adapters.onebot.v11 import MessageSegment
 
@@ -82,8 +82,9 @@ async def get_pic_from_url(url: str):
     :return:
     """
     async with aiohttp.ClientSession() as session:
-        async with session.get(url) as resp:
-            content = io.BytesIO(await resp.read())
+        async with httpx.AsyncClient(verify=True) as client:
+            response = await client.get(url)
+            content = io.BytesIO(response.content)
         data = aiohttp.FormData()  # boundary="----WebKitFormBoundaryPpuR3EZ1Ap2pXv8W"
         data.add_field(
             name="file", value=content, content_type="image/png", filename="blob"

--- a/nonebot_plugin_picsearcher/trace.py
+++ b/nonebot_plugin_picsearcher/trace.py
@@ -3,7 +3,7 @@ from base64 import b64encode
 from copy import deepcopy
 from typing import List, Tuple
 
-import aiohttp
+import aiohttp,httpx
 from nonebot.adapters.onebot.v11 import MessageSegment
 
 # from .formdata import FormData
@@ -95,7 +95,9 @@ async def get_pic_from_url(url: str):
     """
     async with aiohttp.ClientSession() as session:
         async with session.get(url) as resp:
-            content = io.BytesIO(await resp.read())
+            async with httpx.AsyncClient(verify=True) as client:
+                response = await client.get(url)
+                content = io.BytesIO(response.content)
         # with open("F:\elu.PNG", "rb") as f:
         #     content = io.BytesIO(f.read())
         data = aiohttp.FormData()  # boundary="----WebKitFormBoundary9cyjY8YBBN8SGdG4"


### PR DESCRIPTION
修复部分方法中的SSLV3_ALERT_HANDSHAKE_FAILURE问题

![image](https://github.com/user-attachments/assets/67ba5b8d-ac77-4d2b-9ee5-cc3a5f9d5abd)

## Summary by Sourcery

Replace aiohttp with httpx in multiple methods to fix SSLV3_ALERT_HANDSHAKE_FAILURE issues during HTTP requests.

Bug Fixes:
- Resolve SSLV3_ALERT_HANDSHAKE_FAILURE issues by replacing aiohttp with httpx for HTTP requests.